### PR TITLE
Migrate away from redux to @mattermost packages in TS example

### DIFF
--- a/typescript/hello-world/package-lock.json
+++ b/typescript/hello-world/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@mattermost/client": "^7.4.0",
+        "@mattermost/types": "7.4.0",
         "express": "4.17.1",
         "mattermost-redux": "5.33.1",
         "node-fetch": "2.6.1"
@@ -2137,6 +2139,49 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@mattermost/client": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@mattermost/client/-/client-7.4.0.tgz",
+      "integrity": "sha512-D9Uf8aKVKC1lWpNYHWm9NMjiEl60/0aMuTfoVN0QYXySEXjhfZ6kXxQT3n0NK2cY6tzr6ERYce07Z3m7XGEy3w==",
+      "dependencies": {
+        "form-data": "^4.0.0"
+      },
+      "peerDependencies": {
+        "@mattermost/types": "*",
+        "typescript": "^4.3"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mattermost/client/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@mattermost/types": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@mattermost/types/-/types-7.4.0.tgz",
+      "integrity": "sha512-9HuONuN6L5TqhEHUzEmZwmINg22/egdB90vXFmFiNoocfdwbC7buzxDK7YiNJNHxyZtAVxA/cqtavEeT/qF6wQ==",
+      "peerDependencies": {
+        "typescript": "^4.3"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@react-native-community/cli": {
@@ -9118,7 +9163,7 @@
       "version": "4.7.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
       "integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11157,6 +11202,32 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "@mattermost/client": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@mattermost/client/-/client-7.4.0.tgz",
+      "integrity": "sha512-D9Uf8aKVKC1lWpNYHWm9NMjiEl60/0aMuTfoVN0QYXySEXjhfZ6kXxQT3n0NK2cY6tzr6ERYce07Z3m7XGEy3w==",
+      "requires": {
+        "form-data": "^4.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
+    "@mattermost/types": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@mattermost/types/-/types-7.4.0.tgz",
+      "integrity": "sha512-9HuONuN6L5TqhEHUzEmZwmINg22/egdB90vXFmFiNoocfdwbC7buzxDK7YiNJNHxyZtAVxA/cqtavEeT/qF6wQ==",
+      "requires": {}
     },
     "@react-native-community/cli": {
       "version": "8.0.6",
@@ -16748,7 +16819,7 @@
       "version": "4.7.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
       "integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
-      "dev": true
+      "devOptional": true
     },
     "uglify-es": {
       "version": "3.3.9",

--- a/typescript/hello-world/package.json
+++ b/typescript/hello-world/package.json
@@ -8,8 +8,9 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@mattermost/client": "7.4.0",
+    "@mattermost/types": "7.4.0",
     "express": "4.17.1",
-    "mattermost-redux": "5.33.1",
     "node-fetch": "2.6.1"
   },
   "devDependencies": {

--- a/typescript/hello-world/src/app.ts
+++ b/typescript/hello-world/src/app.ts
@@ -6,11 +6,11 @@ import express from 'express';
 // Shim for mattermost-redux global fetch access
 global.fetch = require('node-fetch');
 
-import {AppBinding, AppCallRequest, AppCallResponse, AppForm, AppManifest} from 'mattermost-redux/types/apps';
-import {Post} from 'mattermost-redux/types/posts';
-import {Channel} from 'mattermost-redux/types/channels';
+import {AppBinding, AppCallRequest, AppCallResponse, AppForm, AppManifest} from '@mattermost/types/lib/apps';
+import {Post} from '@mattermost/types/lib/posts';
+import {Channel} from '@mattermost/types/lib/channels';
 
-import Client4 from 'mattermost-redux/client/client4';
+import {Client4} from '@mattermost/client';
 
 const host = process.env.APP_HOST || 'localhost';
 const port = process.env.APP_PORT || 4000;
@@ -169,7 +169,7 @@ app.post('/submit', async (req, res) => {
 
     const callResponse: AppCallResponse = {
         type: 'ok',
-        markdown: 'Created a post in your DM channel.',
+        text: 'Created a post in your DM channel.',
     };
 
     res.json(callResponse);

--- a/typescript/hello-world/tsconfig.json
+++ b/typescript/hello-world/tsconfig.json
@@ -18,7 +18,10 @@
       ],
       "resolveJsonModule": true,
       "esModuleInterop": true,
-      "skipLibCheck": true
+      "skipLibCheck": true,
+      "paths": {
+            "@mattermost/types/*": ["node_modules/@mattermost/types/lib/*"]
+      }
     },
     "include": [
       "./src",


### PR DESCRIPTION
#### Summary
`mattermost-redux` is deprecated. This PR makes use of two new packages `@mattermost/client` and `@mattermost/types`.

#### Ticket Link
https://community.mattermost.com/core/pl/fnzkt7xnrtb1p861qx6zj7jtww

