### PR TITLE
Expand acting user and access token in appform for typescript hello-world app

### DIFF
--- a/typescript/hello-world/src/app.ts
+++ b/typescript/hello-world/src/app.ts
@@ -64,6 +64,10 @@ const form: AppForm = {
     ],
     submit: {
         path: '/submit',
+        expand: {
+            acting_user: "all",
+            acting_user_access_token: "all"
+        }
     },
 };
 


### PR DESCRIPTION
#### Summary

When submitting the hellow-world appform in the typescript implementation, the user will get an error:
> upstream call failed: failed to invoke via HTTP: Post "http://mattermost-apps-golang-hello-world:4000/send": EOF

This seems to be the same issue that was present in the Golang hello-world implementation but was fixed:
https://github.com/mattermost/mattermost-app-examples/issues/14

To fix this, the acting_user object needs expansion.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-app-examples/issues/14