### PR TITLE
Fix #18. Missing manifest node.

### DIFF
--- a/python/hello-world/src/hello-world.py
+++ b/python/hello-world/src/hello-world.py
@@ -51,7 +51,9 @@ def manifest() -> dict:
             '/channel_header',
             '/command'
         ],
-        'root_url': os.environ.get('ROOT_URL', default_root_url),
+        'http': {
+	        'root_url': os.environ.get('ROOT_URL', default_root_url),
+		},
     }
 
 

--- a/typescript/hello-world/src/app.ts
+++ b/typescript/hello-world/src/app.ts
@@ -41,7 +41,9 @@ const manifest = {
     homepage_url: 'https://github.com/mattermost/mattermost-app-examples/typescript/hello-world',
     app_type: 'http',
     icon: 'icon.png',
-    root_url: `http://${host}:${port}`,
+	http: {
+	    root_url: `http://${host}:${port}`,
+	},
     requested_permissions: [
         'act_as_bot',
     ],

--- a/typescript/hello-world/src/app.ts
+++ b/typescript/hello-world/src/app.ts
@@ -41,9 +41,9 @@ const manifest = {
     homepage_url: 'https://github.com/mattermost/mattermost-app-examples/typescript/hello-world',
     app_type: 'http',
     icon: 'icon.png',
-	http: {
-	    root_url: `http://${host}:${port}`,
-	},
+    http: {
+        root_url: `http://${host}:${port}`,
+    },
     requested_permissions: [
         'act_as_bot',
     ],


### PR DESCRIPTION
#### Summary
The sample http apps fail to install due to an incorrect manifest.

Repro steps:
1. Follow the instructions on https://developers.mattermost.com/integrate/apps/quickstart/quick-start-ts/
2. Error: "manifest has no deployment information (http, aws_lambda, open_faas, etc.)"

Expected:
* App installs correctly

This error occurs for both the Typescript and Python examples. The cause is there is a missing "http" node in the manifest.

#### Ticket Link
https://github.com/mattermost/mattermost-app-examples/issues/18